### PR TITLE
Add GH's 1.3/OfficialCurrentGPP protocol (71)

### DIFF
--- a/apelsin.cabal
+++ b/apelsin.cabal
@@ -9,7 +9,8 @@ Category:               Network
 Synopsis:               Server and community browser for the game Tremulous
 Description:
   A gtk2hs server and clan browser for the open source game Tremulous
-  <http://tremulous.net>. Both Tremulous 1.1 and GPP are supported.
+  <http://tremulous.net>. Both Tremulous 1.1, GPP and 1.3 (protocol 71)
+  are supported. Unvanquished is included as an extra (Protocol 86
 
   Features filtering, player search, a list of online clan members,
   a clan list and basic perferences.

--- a/apelsin.cabal
+++ b/apelsin.cabal
@@ -10,7 +10,7 @@ Synopsis:               Server and community browser for the game Tremulous
 Description:
   A gtk2hs server and clan browser for the open source game Tremulous
   <http://tremulous.net>. Both Tremulous 1.1, GPP and 1.3 (protocol 71)
-  are supported. Unvanquished is included as an extra (Protocol 86
+  are supported. Unvanquished is included as an extra (Protocol 86)
 
   Features filtering, player search, a list of online clan members,
   a clan list and basic perferences.

--- a/packages/pacman/PKGBUILD
+++ b/packages/pacman/PKGBUILD
@@ -18,6 +18,7 @@ depends=('gmp' 'gtk2' 'hicolor-icon-theme')
 
 optdepends=('tremulous: Launch Tremulous 1.1 games'
             'tremulous-gpp: Launch Tremulous GPP games'
+            'tremulous-1.3: Launch Tremulous 1.3 games'
             'unvanquished: Launch Unvanquished games')
 
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -61,6 +61,7 @@ defaultConfig :: Config
 defaultConfig = Config
     { masterServers         = [ ("master.tremulous.net", 30710, 69)
                               , ("master.tremulous.net", 30700, 70)
+                              , ("master.tremulous.net", 30700, 71)
                               , ("unvanquished.net", 27950, 86)
                               ]
     , clanlistURL           = "http://ddos-tremulous.eu/cw/api/2/clanlist"

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -39,6 +39,7 @@ data Config = Config
     , clanlistURL           :: !String
     , tremulousPath
     , tremulousGppPath
+    , tremulous13Path
     , unvanquishedPath      :: !String
     , refreshMode           :: !RefreshMode
     , autoClan
@@ -69,10 +70,12 @@ defaultConfig = Config
 #if defined(mingw32_HOST_OS) || defined(__MINGW32__)
     , tremulousPath         = "C:\\Program Files\\Tremulous\\tremulous.exe"
     , tremulousGppPath      = "C:\\Program Files\\Tremulous\\tremulous-gpp.exe"
+    , tremulous13Path      = "C:\\Program Files\\Tremulous\\tremulous.exe"
     , unvanquishedPath      = "C:\\Program Files (x86)\\Unvanquished\\daemon.exe"
 #else
     , tremulousPath         = "tremulous"
     , tremulousGppPath      = "tremulous-gpp"
+    , tremulous13Path      = "tremulous"
     , unvanquishedPath      = "unvanquished"
 #endif
 

--- a/src/Preferences.hs
+++ b/src/Preferences.hs
@@ -43,7 +43,8 @@ newPreferences Bundle{..} = do
 	path_table       <- paddedTableNew
 	tremulousPath    <- pathInsertTable parent path_table 0 "_Tremulous 1.1:"
 	tremulousGppPath <- pathInsertTable parent path_table 1 "Tremulous _GPP:"
-	unvanquishedPath <- pathInsertTable parent path_table 2 "_Unvanquished:"
+	tremulous13Path  <- pathInsertTable parent path_table 2 "Tremulous _1.3:"
+	unvanquishedPath <- pathInsertTable parent path_table 3 "_Unvanquished:"
 	paths            <- framed "Path or command" path_table
 
 	-- Startup
@@ -116,6 +117,7 @@ newPreferences Bundle{..} = do
 		set showEmpty		[ toggleButtonActive := C.showEmpty c]
 		set tremulousPath	[ entryText := C.tremulousPath c ]
 		set tremulousGppPath	[ entryText := C.tremulousGppPath c]
+		set tremulous13Path	[ entryText := C.tremulous13Path c]
 		set unvanquishedPath	[ entryText := C.unvanquishedPath c]
 		set autoClan		[ toggleButtonActive := C.autoClan c]
 		set restoreGeometry	[ toggleButtonActive := C.restoreGeometry c]

--- a/src/ServerInfo.hs
+++ b/src/ServerInfo.hs
@@ -295,6 +295,7 @@ protocolToPath :: Config -> Int -> Maybe FilePath
 protocolToPath c proto = case proto of
 	69 -> Just (tremulousPath c)
 	70 -> Just (tremulousGppPath c)
+	71 -> Just (tremulous13path c)
 	86 -> Just (unvanquishedPath c)
 	_  -> Nothing
 

--- a/src/TremFormatting.hs
+++ b/src/TremFormatting.hs
@@ -50,11 +50,13 @@ protoToAbbr, protoToFull :: IsString s => Int ->  s
 protoToAbbr x = case x of
 	69 -> "1.1"
 	70 -> "gpp"
+	71 -> "1.3"
 	86 -> "unv"
 	_  -> "?"
 
 protoToFull x = case x of
 	69 -> "Tremulous 1.1"
 	70 -> "Tremulous GPP"
+	71 -> "Tremulous 1.3"
 	86 -> "Unvanquished"
 	_  -> "<Unknown>"


### PR DESCRIPTION
Also check the commit for 1.3(7). I don't know what the underscores are so I just guessed it, will probably need correctin.

This is just a quick attempt to provide support for the protocol 71, which is used by GrangerHub's and DarklegionDev's current GPP client/server.

I may also add Q2 Gloom/Murnatan support in the future but not for now as I don't have the knowledge to go that far yet